### PR TITLE
Add support for a GitHub CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+
+jobs:
+  ci:
+    if: github.repository == 'skirtles-code/create-vue-lib'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Lint
+        run: pnpm run lint
+      - name: Build
+        run: pnpm run build
+      - name: Test
+        run: pnpm run test:unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: pnpm install
       - name: Lint
         run: pnpm run lint
+      - name: Type check
+        run: pnpm run type-check
       - name: Build
         run: pnpm run build
-      - name: Test
-        run: pnpm run test:unit

--- a/packages/create-vue-lib/src/index.ts
+++ b/packages/create-vue-lib/src/index.ts
@@ -83,6 +83,7 @@ type Config = {
   includeEsLint: boolean
   includeEsLintStylistic: boolean
   includeVitest: boolean
+  includeGithubCi: boolean
   includeAtAliases: boolean
   includeTestVariable: boolean
 }
@@ -268,6 +269,7 @@ async function init() {
   const includeDocs = await togglePrompt('Include VitePress for documentation?', true)
   const includeGithubPages = includeDocs && await togglePrompt('Include GitHub Pages config for documentation?')
   const includePlayground = await togglePrompt('Include playground application for development?', true)
+  const includeGithubCi = await togglePrompt('Include GitHub CI configuration?', !!githubPath)
   const includeExamples = await togglePromptIf(extended, 'Include example code?', true, 'Yes', 'No, just configs')
   const includeAtAliases = await togglePromptIf(extended, 'Configure @ as an alias for src?')
   const includeTestVariable = await togglePromptIf(extended, 'Configure global __TEST__ variable?')
@@ -334,6 +336,7 @@ async function init() {
     includeEsLint,
     includeEsLintStylistic,
     includeVitest,
+    includeGithubCi,
     includeAtAliases,
     includeTestVariable
   }
@@ -358,6 +361,10 @@ async function init() {
 
   if (config.includeVitest) {
     copyTemplate('vitest', config)
+  }
+
+  if (config.includeGithubCi) {
+    copyTemplate('ci', config)
   }
 
   console.log()

--- a/packages/create-vue-lib/src/template/ci/config/.github/workflows/ci.yml.ejs
+++ b/packages/create-vue-lib/src/template/ci/config/.github/workflows/ci.yml.ejs
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+
+jobs:
+  ci:
+<%_ if (config.githubPath) { _%>
+    if: github.repository == '<%- config.githubPath %>'
+<%_ } _%>
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+<%_ if (config.includeEsLint) { _%>
+      - name: Lint
+        run: pnpm run lint
+<%_ } _%>
+      - name: Type check
+        run: pnpm run type-check
+      - name: Build
+        run: pnpm run build
+<%_ if (config.includeVitest) { _%>
+      - name: Test
+        run: pnpm run test:unit
+<%_ } _%>

--- a/packages/docs/src/questions.md
+++ b/packages/docs/src/questions.md
@@ -50,6 +50,7 @@
 <span class="check">✔</span> <a href="#include-vitepress">Include VitePress for documentation? … No / Yes</a>
 <span class="check">✔</span> <a href="#include-github-pages">Include GitHub Pages config for documentation? … No / Yes</a>
 <span class="check">✔</span> <a href="#include-playground">Include playground application for development? … No / Yes</a>
+<span class="check">✔</span> <a href="#include-github-ci">Include GitHub CI configuration? … No / Yes</a>
 <span class="check">✔</span> <a href="#include-examples">Include example code? … No, just configs / Yes</a>
 <span class="check">✔</span> <a href="#configure-src-alias">Configure @ as an alias for src? … No / Yes</a>
 <span class="check">✔</span> <a href="#configure-test-variable">Configure global __TEST__ variable?</a></pre>
@@ -190,6 +191,14 @@ While you're developing your library, you can use the playground application to 
 This isn't a playground in the same sense as the official Vue playground. Instead, it's just an application that is pre-configured to be able to use your library.
 
 The playground application will use your library direct from the source code, without needing to build the library separately. This is usually beneficial, as it allows for quicker development and immediate feedback on changes. But it does make the playground slightly less representative of a real consuming application, as it isn't using the built files.
+
+## Include GitHub CI configuration?{#include-github-ci}
+
+Continuous Integration (CI) is used to help catch problems as soon as they occur.
+
+This option will include a GitHub Actions configuration for a CI workflow. It will run the `lint`, `type-check`, `build` and `test:unit` targets from the `scripts` section of the root `package.json`. The workflow is triggered by any PRs opened against the `main` branch, as well as when changes are pushed to `main`.
+
+If a [GitHub path](#github-path) has been provided, the job will be configured so that it only runs for that specific fork.
 
 ## Include example code?{#include-examples}
 


### PR DESCRIPTION
Closes #3.

- Add a CI job for the project itself.
- Add support for including a CI job in the generated project.