### PR TITLE
Update template dependencies and sync with create-vue 3.16.0

### DIFF
--- a/packages/create-vue-lib/src/template/base/config/.vscode/settings.json.ejs
+++ b/packages/create-vue-lib/src/template/base/config/.vscode/settings.json.ejs
@@ -3,7 +3,7 @@
   "explorer.fileNesting.patterns": {
     "tsconfig.json": "tsconfig.*.json, env.d.ts",
     "vite.config.*": "jsconfig*, vitest.config.*, cypress.config.*, playwright.config.*",
-    "package.json": "package-lock.json, pnpm*, .yarnrc*, yarn*, .eslint*, eslint*, .prettier*, prettier*, .editorconfig"
+    "package.json": "package-lock.json, pnpm*, .yarnrc*, yarn*, .eslint*, eslint*, .oxlint*, oxlint*, .prettier*, prettier*, .editorconfig"
   },
   <%_ if (config.includeEsLint) { _%>
   "editor.codeActionsOnSave": {

--- a/packages/create-vue-lib/src/template/base/config/package.json.ejs
+++ b/packages/create-vue-lib/src/template/base/config/package.json.ejs
@@ -7,23 +7,23 @@
   },
   "devDependencies": {
     <%_ if (config.includeEsLint) { _%>
-    "@eslint/compat": "^1.2.7",
+    "@eslint/compat": "^1.2.8",
     <%_ if (config.includeEsLintStylistic) { _%>
     "@stylistic/eslint-plugin": "^4.2.0",
     <%_ } _%>
-    "@tsconfig/node22": "^22.0.0",
-    "@types/node": "^22.13.9",
+    "@tsconfig/node22": "^22.0.1",
+    "@types/node": "^22.13.14",
     <%_ if (config.includeVitest) { _%>
-    "@vitest/eslint-plugin": "^1.1.36",
+    "@vitest/eslint-plugin": "^1.1.38",
     <%_ } _%>
     "@vue/eslint-config-typescript": "^14.5.0",
-    "eslint": "^9.21.0",
+    "eslint": "^9.22.0",
     "eslint-plugin-vue": "~10.0.0",
     "jiti": "^2.4.2",
-    "lint-staged": "^15.4.3",
+    "lint-staged": "^15.5.0",
     "npm-run-all2": "^7.0.2",
     <%_ } _%>
-    "simple-git-hooks": "^2.11.1",
+    "simple-git-hooks": "^2.12.1",
     <%_ if (config.includeEsLint) { _%>
     "typescript": "~5.8.0"
     <%_ } _%>

--- a/packages/create-vue-lib/src/template/base/config/packages/@projectName@/package.json.ejs
+++ b/packages/create-vue-lib/src/template/base/config/packages/@projectName@/package.json.ejs
@@ -39,25 +39,25 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^6.0.2",
-    "@tsconfig/node22": "^22.0.0",
+    "@tsconfig/node22": "^22.0.1",
     "@types/jsdom": "^21.1.7",
-    "@types/node": "^22.13.9",
-    "@vitejs/plugin-vue": "^5.2.1",
+    "@types/node": "^22.13.14",
+    "@vitejs/plugin-vue": "^5.2.3",
     <%_ if (config.includeVitest) { _%>
-    "@vitest/coverage-v8": "^3.0.8",
+    "@vitest/coverage-v8": "^3.1.1",
     "@vue/test-utils": "^2.4.6",
     <%_ } _%>
     "@vue/tsconfig": "^0.7.0",
     "copyfiles": "^2.4.1",
     "jsdom": "^26.0.0",
     "npm-run-all2": "^7.0.2",
-    "publint": "^0.3.8",
+    "publint": "^0.3.9",
     "rimraf": "^5.0.1",
     "typescript": "~5.8.0",
-    "vite": "^6.2.1",
+    "vite": "^6.2.4",
     "vite-plugin-dts": "^4.5.3",
     <%_ if (config.includeVitest) { _%>
-    "vitest": "^3.0.8",
+    "vitest": "^3.1.1",
     <%_ } _%>
     "vue": "^3.5.13",
     "vue-tsc": "^2.2.8"

--- a/packages/create-vue-lib/src/template/playground/config/packages/playground/package.json
+++ b/packages/create-vue-lib/src/template/playground/config/packages/playground/package.json
@@ -5,14 +5,14 @@
     "vue": "^3.5.13"
   },
   "devDependencies": {
-    "@tsconfig/node22": "^22.0.0",
-    "@types/node": "^22.13.9",
-    "@vitejs/plugin-vue": "^5.2.1",
+    "@tsconfig/node22": "^22.0.1",
+    "@types/node": "^22.13.14",
+    "@vitejs/plugin-vue": "^5.2.3",
     "@vue/tsconfig": "^0.7.0",
     "npm-run-all2": "^7.0.2",
     "rimraf": "^5.0.1",
     "typescript": "~5.8.0",
-    "vite": "^6.2.1",
+    "vite": "^6.2.4",
     "vite-plugin-vue-devtools": "^7.7.2",
     "vue-tsc": "^2.2.8"
   },

--- a/packages/create-vue-lib/src/template/vitepress/config/packages/docs/package.json
+++ b/packages/create-vue-lib/src/template/vitepress/config/packages/docs/package.json
@@ -5,11 +5,11 @@
     "vue": "^3.5.13"
   },
   "devDependencies": {
-    "@tsconfig/node22": "^22.0.0",
-    "@types/node": "^22.13.9",
+    "@tsconfig/node22": "^22.0.1",
+    "@types/node": "^22.13.14",
     "@vue/tsconfig": "^0.7.0",
     "npm-run-all2": "^7.0.2",
-    "rimraf": "^6.0.1",
+    "rimraf": "^5.0.1",
     "typescript": "~5.8.0",
     "vitepress": "^1.6.3",
     "vue-tsc": "^2.2.8"


### PR DESCRIPTION
- `settings.json.ejs` is updated to match `create-vue@3.16.0`.
- Dependencies in template `package.json` files are updated to match `create-vue@3.16.0`, or to latest version in cases where the dependencies aren't included by `create-vue`.
- `rimraf` is now consistently using `5.0.1`.