### PR TITLE
Fix a 'Pre-transform error' using aliases with Vite

### DIFF
--- a/packages/create-vue-lib/src/template/playground/config/packages/playground/vite.config.mts.ejs
+++ b/packages/create-vue-lib/src/template/playground/config/packages/playground/vite.config.mts.ejs
@@ -21,11 +21,13 @@ export default defineConfig(({ mode }): UserConfig => ({
       {
         find: '@',
         replacement: '@',
-        customResolver(source, importer) {
-          return source.replace(
+        customResolver(source, importer, options) {
+          const filePath = source.replace(
             /^@\//,
             importer?.startsWith(librarySrc) ? librarySrc : playgroundSrc
           )
+
+          return this.resolve(filePath, importer, options)
         }
       }, {
         find: '<%- config.scopedPackageName %>',

--- a/packages/create-vue-lib/src/template/vitepress/config/packages/docs/.vitepress/config.mts.ejs
+++ b/packages/create-vue-lib/src/template/vitepress/config/packages/docs/.vitepress/config.mts.ejs
@@ -4,7 +4,7 @@ import { defineConfigWithTheme } from 'vitepress'
 
 <%_ if (config.includeAtAliases) { _%>
 const librarySrc = fileURLToPath(new URL('../../<%- config.mainPackageDirName %>/src/', import.meta.url))
-const playgroundSrc = fileURLToPath(new URL('../src/', import.meta.url))
+const docsSrc = fileURLToPath(new URL('../src/', import.meta.url))
 <%_ } _%>
 
 export default ({ mode }: { mode: string }) => defineConfigWithTheme({
@@ -40,11 +40,13 @@ export default ({ mode }: { mode: string }) => defineConfigWithTheme({
         {
           find: '@',
           replacement: '@',
-          customResolver(source, importer) {
-            return source.replace(
+          customResolver(source, importer, options) {
+            const filePath = source.replace(
               /^@\//,
-              importer?.startsWith(librarySrc) ? librarySrc : playgroundSrc
+              importer?.startsWith(librarySrc) ? librarySrc : docsSrc
             )
+
+            return this.resolve(filePath, importer, options)
           }
         }, {
           find: '<%- config.scopedPackageName %>',


### PR DESCRIPTION
This fixes a problem reported in #7.

When using `@` aliases with `shadcn-vue`, there's an error trying to run the playground and docs packages:

> `Pre-transform error: Failed to load url /src/lib/utils`

The relevant code is:

```js
import { cn } from '@/lib/utils'
```

The problem isn't unique to `shadcn-vue`, the same thing would happen for other uses of `@` aliases that don't resolve exactly to a file. For example, any imports that don't include the extension, or that rely on resolving to an `index` file.

The solution implemented here is to pass the new path through `this.resolve()`, after the `@` has been replaced. This will apply the other resolution rules required to handle those cases.

These changes should allow Vite to resolve the aliases correctly, both during dev and for a production build.

There is a related problem with the `type-check` command. This is still failing to resolve the aliases correctly in the playground and docs packages.