### PR TITLE
Refactor to use only EJS for templating

### DIFF
--- a/packages/create-vue-lib/src/index.ts
+++ b/packages/create-vue-lib/src/index.ts
@@ -474,14 +474,6 @@ function copyFiles(templateFile: string, config: Config) {
 
     fs.writeFileSync(target, content)
   }
-  else if (['package.json', 'vite.config.mts', 'config.mts', 'index.md', 'introduction.md', 'App.vue', 'tsconfig.app.json', 'env.d.ts'].includes(filename)) {
-    const template = fs.readFileSync(templatePath, 'utf-8')
-    const content = template
-      .replace(/@projectName@/g, config.mainPackageDirName)
-      .replace(new RegExp(`@(${Object.keys(config).join('|')})@`, 'g'), (all, setting) => `${config[setting as keyof Config] ?? all}`)
-
-    fs.writeFileSync(targetPath, content)
-  }
   else {
     fs.copyFileSync(templatePath, targetPath)
   }

--- a/packages/create-vue-lib/src/template/playground/config/packages/playground/env.d.ts
+++ b/packages/create-vue-lib/src/template/playground/config/packages/playground/env.d.ts
@@ -1,3 +1,0 @@
-/// <reference types="vite/client" />
-
-import '../@projectName@/env.d.ts'

--- a/packages/create-vue-lib/src/template/playground/config/packages/playground/env.d.ts.ejs
+++ b/packages/create-vue-lib/src/template/playground/config/packages/playground/env.d.ts.ejs
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+import '../<%- config.mainPackageDirName %>/env.d.ts'

--- a/packages/create-vue-lib/src/template/vitepress/config/packages/docs/env.d.ts
+++ b/packages/create-vue-lib/src/template/vitepress/config/packages/docs/env.d.ts
@@ -1,3 +1,0 @@
-/// <reference types="vite/client" />
-
-import '../@projectName@/env.d.ts'

--- a/packages/create-vue-lib/src/template/vitepress/config/packages/docs/env.d.ts.ejs
+++ b/packages/create-vue-lib/src/template/vitepress/config/packages/docs/env.d.ts.ejs
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+import '../<%- config.mainPackageDirName %>/env.d.ts'

--- a/packages/create-vue-lib/src/template/vitepress/examples/packages/docs/src/index.md.ejs
+++ b/packages/create-vue-lib/src/template/vitepress/examples/packages/docs/src/index.md.ejs
@@ -1,11 +1,11 @@
 ---
 layout: home
 
-title: @unscopedPackageName@
+title: <%- config.unscopedPackageName %>
 titleTemplate: Title template
 
 hero:
-  name: @unscopedPackageName@
+  name: <%- config.unscopedPackageName %>
   text: Description
   tagline: Tag line!
   actions:
@@ -14,7 +14,7 @@ hero:
       link: /introduction
     - theme: alt
       text: View on GitHub
-      link: https://github.com/@githubPath@
+      link: https://github.com/<%- config.githubPath %>
     - theme: alt
       text: See a demo
       link: https://play.vuejs.org/


### PR DESCRIPTION
The use of `@configProperty@` syntax has been removed. All templating for file contents now uses EJS.