### PR TITLE
Add `pkg-pr-new` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,5 @@ jobs:
         run: pnpm run type-check
       - name: Build
         run: pnpm run build
+      - name: Release
+        run: pnpx pkg-pr-new publish --bin --commentWithSha --pnpm './packages/*' --packageManager=pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Build
         run: pnpm run build
       - name: Release
-        run: pnpx pkg-pr-new publish --bin --commentWithSha --pnpm './packages/*' --packageManager=pnpm
+        run: pnpx pkg-pr-new publish --bin --commentWithSha --pnpm --packageManager=pnpm './packages/create-vue-lib'

--- a/packages/create-vue-lib/src/index.ts
+++ b/packages/create-vue-lib/src/index.ts
@@ -85,6 +85,7 @@ type Config = {
   includeEsLintStylistic: boolean
   includeVitest: boolean
   includeGithubCi: boolean
+  includePkgPrNew: boolean
   includeAtAliases: boolean
   includeTestVariable: boolean
   includeTailwind: boolean
@@ -275,6 +276,7 @@ async function init() {
   const includeGithubPages = includeDocs && await togglePrompt('Include GitHub Pages config for documentation?')
   const includePlayground = await togglePrompt('Include playground application for development?', true)
   const includeGithubCi = await togglePrompt('Include GitHub CI configuration?', !!githubPath)
+  const includePkgPrNew = includeGithubCi && await togglePrompt('Include pkg.pr.new in CI configuration?', false)
   const includeExamples = await togglePromptIf(extended, 'Include example code?', true, 'Yes', 'No, just configs')
   const includeAtAliases = await togglePromptIf(extended, 'Configure @ as an alias for src?')
   const includeTestVariable = await togglePromptIf(extended, 'Configure global __TEST__ variable?')
@@ -342,6 +344,7 @@ async function init() {
     includeEsLintStylistic,
     includeVitest,
     includeGithubCi,
+    includePkgPrNew,
     includeAtAliases,
     includeTestVariable,
     includeTailwind,

--- a/packages/create-vue-lib/src/template/ci/config/.github/workflows/ci.yml.ejs
+++ b/packages/create-vue-lib/src/template/ci/config/.github/workflows/ci.yml.ejs
@@ -38,3 +38,7 @@ jobs:
       - name: Test
         run: pnpm run test:unit
 <%_ } _%>
+<%_ if (config.includePkgPrNew) { _%>
+      - name: Release
+        run: pnpx pkg-pr-new publish --commentWithSha --pnpm --packageManager=pnpm,npm,yarn './<%- config.packagesDir %><%- config.mainPackageDirName %>'
+<%_ } _%>

--- a/packages/docs/src/questions.md
+++ b/packages/docs/src/questions.md
@@ -53,6 +53,7 @@
 <span class="check">✔</span> <a href="#include-github-pages">Include GitHub Pages config for documentation? … No / Yes</a>
 <span class="check">✔</span> <a href="#include-playground">Include playground application for development? … No / Yes</a>
 <span class="check">✔</span> <a href="#include-github-ci">Include GitHub CI configuration? … No / Yes</a>
+<span class="check">✔</span> <a href="#include-pkg-pr-new">Include pkg.pr.new in CI configuration? … No / Yes</a>
 <span class="check">✔</span> <a href="#include-examples">Include example code? … No, just configs / Yes</a>
 <span class="check">✔</span> <a href="#configure-src-alias">Configure @ as an alias for src? … No / Yes</a>
 <span class="check">✔</span> <a href="#configure-test-variable">Configure global __TEST__ variable? … No / Yes</a></pre>
@@ -225,6 +226,16 @@ Continuous Integration (CI) is used to help catch problems as soon as they occur
 This option will include a GitHub Actions configuration for a CI workflow. It will run the `lint`, `type-check`, `build` and `test:unit` targets from the `scripts` section of the root `package.json`. The workflow is triggered by any PRs opened against the `main` branch, as well as when changes are pushed to `main`.
 
 If a [GitHub path](#github-path) has been provided, the job will be configured so that it only runs for that specific fork.
+
+## Include pkg.pr.new in CI configuration?{#include-pkg-pr-new}
+
+:::info NOTE
+You'll only see this question if you chose to include GitHub CI configuration.
+:::
+
+[pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new) allows for continuous releases. Every PR and every commit to `main` will be published as a package on pkg.pr.new, which is similar to the npm registry but with each 'release' tied to a specific commit rather than a version number. This allows changes to be installed and tested before they're merged or released to npm.
+
+You'll also need to install the [pkg.pr.new GitHub App](https://github.com/apps/pkg-pr-new) and enable it on your GitHub repository.
 
 ## Include example code?{#include-examples}
 


### PR DESCRIPTION
This enables `pkg-pr-new` for this repo and adds support for it in projects created using `@skirtle/create-vue-lib`.