### PR TITLE
Add npm trusted publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+# Publish package to the npm registry
+name: Publish Package
+
+on:
+  # Run the workflow when a new tag is pushed starting with `v`
+  # push:
+  #  tags:
+  #    - 'v*'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build
+        run: pnpm --dir packages/create-vue-lib run build
+      - name: Publish
+        run: pnpm --dir packages/create-vue-lib publish


### PR DESCRIPTION
This only adds the workflow for publishing `@skirtle/create-vue-lib`, it doesn't add it to the projects it creates. That functionality can be added later once everything is confirmed to be working correctly.