### PR TITLE
Switch `publish.yml` from `--dir` to `--filter`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Build
-        run: pnpm --dir packages/create-vue-lib run build
+        run: pnpm --filter "@skirtle/create-vue-lib" run build
       - name: Publish
-        run: pnpm --dir packages/create-vue-lib publish
+        run: pnpm --filter "@skirtle/create-vue-lib" publish


### PR DESCRIPTION
The `publish.yml` workflow added in #20 doesn't work correctly. It builds successfully but the `publish` fails. The problem seems to be related to the use of `--dir`, so I've switched it to use `--filter` instead. It's not clear to me why `--dir` doesn't work, but arguably `--filter` is more appropriate anyway.