### PR TITLE
Update `pnpm/action-setup` to `v6`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/packages/create-vue-lib/src/template/ci/config/.github/workflows/ci.yml.ejs
+++ b/packages/create-vue-lib/src/template/ci/config/.github/workflows/ci.yml.ejs
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/packages/create-vue-lib/src/template/gh-pages/config/.github/workflows/pages.yml.ejs
+++ b/packages/create-vue-lib/src/template/gh-pages/config/.github/workflows/pages.yml.ejs
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
Update `pnpm/action-setup` to `v6` in all workflows.

The current version, `v4`, yields a warning when running the workflow:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: pnpm/action-setup@v4.

This is likely harmless but it should be fixed by upgrading to the latest version.