### PR TITLE
Deploy docs after publishing a release

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,10 +2,8 @@
 name: Deploy to GitHub Pages
 
 on:
-  # Runs when a new release is created
-  release:
-    types:
-      - created
+  # Allows the workflow to be triggered from other workflows
+  workflow_call:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,3 +34,5 @@ jobs:
         run: pnpm --filter "@skirtle/create-vue-lib" run build
       - name: Publish
         run: pnpm --filter "@skirtle/create-vue-lib" publish
+  docs:
+    uses: ./.github/workflows/pages.yml


### PR DESCRIPTION
Triggering `pages.yml` using `release`/`created` didn't work. The job runs using the release tag, which isn't allowed as GitHub Pages needs to target the `main` branch directly.

This PR switches to using `publish.yml` to trigger `pages.yml`. Arguably this is more correct anyway, as the docs will only be deployed once the package is on the npm registry.