### PR TITLE
Downgrade `pnpm/action-setup` to `v5`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/packages/create-vue-lib/src/template/ci/config/.github/workflows/ci.yml.ejs
+++ b/packages/create-vue-lib/src/template/ci/config/.github/workflows/ci.yml.ejs
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/packages/create-vue-lib/src/template/gh-pages/config/.github/workflows/pages.yml.ejs
+++ b/packages/create-vue-lib/src/template/gh-pages/config/.github/workflows/pages.yml.ejs
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
       - name: Set up Node
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
Downgrade to `pnpm/action-setup@v5`.

`v6` appears to have some serious bugs that need to be fixed before it can be used. Workflows using `v6` report a corrupted `pnpm-lock.yaml`. It also doesn't respect `--frozen-lockfile`, so the 'corrupted' lockfile doesn't fail the build (which it should). Publishing to npm fails because the lockfile is modified.