### PR TITLE
Fix docs type-checking for the Tailwind plugin

### DIFF
--- a/packages/create-vue-lib/src/template/vitepress/config/packages/docs/package.json.ejs
+++ b/packages/create-vue-lib/src/template/vitepress/config/packages/docs/package.json.ejs
@@ -20,6 +20,7 @@
     "tailwindcss": "catalog:",
     <%_ } _%>
     "typescript": "catalog:",
+    "vite": "^5.4.21",
     "vitepress": "catalog:",
     "vue-tsc": "catalog:"
   },


### PR DESCRIPTION
Type checking the `docs` package currently fails when Tailwind is included.

The underlying problem appears to be the Vite version. VitePress is still using Vite 5, whereas everything else is using Vite 7. The return value for the Tailwind plugin is `Plugin`, with `import { Plugin } from 'vite'`, but that is currently resolving from Vite 7, which doesn't match the Vite 5 `Plugin` type needed by the VitePress config.

Tailwind itself is compatible with Vite 5.2.0+.

The solution is to make Vite an explicit dependency in the `package.json` for the `docs` package. This leads to `pnpm` installing two copies of Tailwind in `node_modules`, one for Vite 7 and one for Vite 5. Tailwind itself is the same in both cases, but the nested `node_modules` contains different version of Vite, allowing the types to resolve correctly.

This should benefit any other plugins that rely on Vite's `Plugin` type too.