### PR TITLE
Tighten security precautions in `publish.yml`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,14 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: pnpm install

--- a/packages/create-vue-lib/src/template/npm-publish/config/.github/workflows/publish.yml.ejs
+++ b/packages/create-vue-lib/src/template/npm-publish/config/.github/workflows/publish.yml.ejs
@@ -25,14 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: pnpm install

--- a/packages/docs/src/why.md
+++ b/packages/docs/src/why.md
@@ -167,6 +167,8 @@ By default, this workflow will not run automatically. It must be run manually fr
 
 The workflow will build the package and publish it to the npm registry. It avoids building the other packages, such as the docs or playground, and won't run the tests or linting checks. Those checks are already performed by the CI workflow and aren't strictly required to make a release. It is left to your discretion to decide whether your codebase is ready for a release.
 
+The publishing workflow places greater emphasis on security than the CI workflow. Caching is disabled for installing packages, which helps to protect against cache poising when building the release. It also uses version hashes for `actions/checkout`, `pnpm/action-setup` and `actions/setup-node` to ensure those are specific, trusted versions.
+
 Running the workflow won't make any changes to the code, such as bumping the version number. You'll need to ensure the version is set correctly in the relevant `package.json` before running the workflow.
 
 - See also: [Publishing to npm](publishing)


### PR DESCRIPTION
This PR applies two security precautions to `publish.yml`:

1. Disable caching, to avoid releases being impacted by cache poisoning.
2. Pin versions for `actions/checkout`, `pnpm/action-setup` and `actions/setup-node`. Using hashes ensures we're getting exactly the versions we're expecting.

Similar changes could be made to `ci.yml`, but the benefit is less clear in that case.